### PR TITLE
Scale to min/max

### DIFF
--- a/autoscaler/app.py
+++ b/autoscaler/app.py
@@ -120,7 +120,7 @@ def get_enabled_apps(cf_client):
     kwargs = {'results-per-page': 15}
     for app in cf_client.apps.list(**kwargs):
         app_conf = app['entity']['environment_json'] or {}
-        status = app_conf.get('AUTOSCALING', 'False')
+        status = app_conf.get('X_AUTOSCALING', 'False')
 
         if status in TRUTHY_VALUES:
             enabled_apps.append(app)
@@ -133,12 +133,12 @@ def get_autoscaling_params(cf_app):
 
     app_conf = cf_app['entity']['environment_json'] or {}
 
-    enabled = app_conf.get('AUTOSCALING', 'False') in TRUTHY_VALUES
+    enabled = app_conf.get('X_AUTOSCALING', 'False') in TRUTHY_VALUES
 
     return {
         'enabled': enabled,
-        'min_instances': int(app_conf.get('AUTOSCALING_MIN', DEFAULT_MINIMUM_INSTANCES)),
-        'max_instances': int(app_conf.get('AUTOSCALING_MAX', DEFAULT_MAXIMUM_INSTANCES)),
+        'min_instances': int(app_conf.get('X_AUTOSCALING_MIN', DEFAULT_MINIMUM_INSTANCES)),
+        'max_instances': int(app_conf.get('X_AUTOSCALING_MAX', DEFAULT_MAXIMUM_INSTANCES)),
         'instances': int(cf_app['entity']['instances']),
         'threshold_period': DEFAULT_THRESHOLD_PERIOD_MINUTES,
         'high_threshold': DEFAULT_HIGH_THRESHOLD_CPU_PERCENTAGE,

--- a/autoscaler/app.py
+++ b/autoscaler/app.py
@@ -278,6 +278,17 @@ async def autoscale(conn):
             await notify(app_name, 'is in cool down period', is_verbose=True)
             continue
 
+        # if we're above or below min/max instances then scale up/down by one instance
+        if params['instances'] > params['max_instances']:
+            await notify(app_name, 'scaled down as instance count is above maximum')
+            await scale(app, space_name, params['instances'] - 1, conn)
+            continue
+
+        if params['instances'] < params['min_instances']:
+            await notify(app_name, 'scaled up as instance count is below minimum')
+            await scale(app, space_name, params['instances'] + 1, conn)
+            continue
+
         try:
             average_cpu = await get_avg_cpu(app_name, space_name, params['threshold_period'], conn)
         except InsufficientData:

--- a/autoscaler/test_app.py
+++ b/autoscaler/test_app.py
@@ -208,11 +208,10 @@ async def test_autoscale_insufficient_data(mocker, app_factory, conn):
     mock_get_client = mocker.patch('autoscaler.app.get_client')
     mock_get_client.return_value.apps.list.return_value = apps
     with async_patch('autoscaler.app.notify') as mock_notify:
-        counts = await autoscale(conn)
+        with async_patch('autoscaler.app.scale') as mock_scale:
+            await autoscale(conn)
 
-    assert mock_notify.call_args[0] == ('test_app', 'insufficient data')
-    assert counts['insufficient_data'] == 1
-
+    assert not mock_scale.called
 
 @pytest.mark.asyncio
 async def test_autoscale_at_min_scale(mocker, app_factory, conn, create_metric):
@@ -228,11 +227,11 @@ async def test_autoscale_at_min_scale(mocker, app_factory, conn, create_metric):
     mock_get_client = mocker.patch('autoscaler.app.get_client')
     mock_get_client.return_value.apps.list.return_value = apps
     with async_patch('autoscaler.app.notify') as mock_notify:
-        counts = await autoscale(conn)
+        with async_patch('autoscaler.app.scale') as mock_scale:
+            await autoscale(conn)
 
-    assert counts['at_min_scale'] == 1
-    assert mock_notify.called
-    assert mock_notify.call_args[0] == ('test_app', 'cannot scale down - already at min')
+    assert not mock_notify.called
+    assert not mock_scale.called
 
 
 @pytest.mark.asyncio
@@ -249,11 +248,11 @@ async def test_autoscale_at_max_scale(mocker, app_factory, conn, create_metric):
     mock_get_client = mocker.patch('autoscaler.app.get_client')
     mock_get_client.return_value.apps.list.return_value = apps
     with async_patch('autoscaler.app.notify') as mock_notify:
-        counts = await autoscale(conn)
+        with async_patch('autoscaler.app.scale') as mock_scale:
+            await autoscale(conn)
 
-    assert counts['at_max_scale'] == 1
-    assert mock_notify.called
-    assert mock_notify.call_args[0] == ('test_app', 'cannot scale up - already at max')
+    assert not mock_notify.called
+    assert not mock_scale.called
 
 
 @pytest.mark.asyncio

--- a/autoscaler/test_app.py
+++ b/autoscaler/test_app.py
@@ -16,8 +16,8 @@ async def reset_database(conn):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    ({'AUTOSCALING': 'on'}, True),
-    ({'AUTOSCALING': 'off'}, False),
+    ({'X_AUTOSCALING': 'on'}, True),
+    ({'X_AUTOSCALING': 'off'}, False),
     ({}, False),
 ])
 def test_get_autoscaling_params_autoscaling(app_factory, test_input, expected):
@@ -29,7 +29,7 @@ def test_get_autoscaling_params_autoscaling(app_factory, test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    ({'AUTOSCALING_MIN': 1, 'AUTOSCALING_MAX': 20},
+    ({'X_AUTOSCALING_MIN': 1, 'X_AUTOSCALING_MAX': 20},
      {'min': 1, 'max': 20}),
     ({}, {'min': main.DEFAULT_MINIMUM_INSTANCES,
           'max': main.DEFAULT_MAXIMUM_INSTANCES}),
@@ -168,8 +168,8 @@ async def test_get_avg_cpu_insufficient_data(create_metric, conn):
 
 def test_get_enabled_apps(mocker, app_factory):
     apps = [
-        app_factory('test_app1', 'test_space1', AUTOSCALING='False'),
-        app_factory('test_app2', 'test_space2', AUTOSCALING='on'),
+        app_factory('test_app1', 'test_space1', X_AUTOSCALING='False'),
+        app_factory('test_app2', 'test_space2', X_AUTOSCALING='on'),
         app_factory('test_app3', 'test_space3')
     ]
 
@@ -185,7 +185,7 @@ def test_get_enabled_apps(mocker, app_factory):
 @pytest.mark.asyncio
 async def test_autoscale_is_cooldown(mocker, app_factory, conn, create_action):
     apps = [
-        app_factory('test_app', 'test_space', AUTOSCALING='on'),
+        app_factory('test_app', 'test_space', X_AUTOSCALING='on'),
     ]
 
     await create_action(dt.datetime.now(), 'test_app', 'test_space', 1)
@@ -202,7 +202,7 @@ async def test_autoscale_is_cooldown(mocker, app_factory, conn, create_action):
 async def test_autoscale_insufficient_data(mocker, app_factory, conn):
     await reset_database(conn)
     apps = [
-        app_factory('test_app', 'test_space', AUTOSCALING='on'),
+        app_factory('test_app', 'test_space', X_AUTOSCALING='on'),
     ]
 
     mock_get_client = mocker.patch('autoscaler.app.get_client')
@@ -219,7 +219,7 @@ async def test_autoscale_at_min_scale(mocker, app_factory, conn, create_metric):
     await reset_database(conn)
 
     apps = [
-        app_factory('test_app', 'test_space', instances=2, AUTOSCALING='on', AUTOSCALING_MIN=2),
+        app_factory('test_app', 'test_space', instances=2, X_AUTOSCALING='on', X_AUTOSCALING_MIN=2),
     ]
 
     for i in range(35):
@@ -240,7 +240,7 @@ async def test_autoscale_at_max_scale(mocker, app_factory, conn, create_metric):
     await reset_database(conn)
 
     apps = [
-        app_factory('test_app', 'test_space', instances=10, AUTOSCALING='on', AUTOSCALING_MAX=10),
+        app_factory('test_app', 'test_space', instances=10, X_AUTOSCALING='on', X_AUTOSCALING_MAX=10),
     ]
 
     for i in range(35):
@@ -262,7 +262,7 @@ async def test_autoscale_scale_up(mocker, app_factory, conn, create_metric):
     await reset_database(conn)
 
     apps = [
-        app_factory('test_app', 'test_space', instances=5, AUTOSCALING='on', AUTOSCALING_MAX=10),
+        app_factory('test_app', 'test_space', instances=5, X_AUTOSCALING='on', X_AUTOSCALING_MAX=10),
     ]
 
     for i in range(35):
@@ -289,7 +289,7 @@ async def test_autoscale_scale_down(mocker, app_factory, conn, create_metric):
     await reset_database(conn)
 
     apps = [
-        app_factory('test_app', 'test_space', instances=5, AUTOSCALING='on', AUTOSCALING_MIN=2),
+        app_factory('test_app', 'test_space', instances=5, X_AUTOSCALING='on', X_AUTOSCALING_MIN=2),
     ]
 
     for i in range(35):

--- a/autoscaler/test_app.py
+++ b/autoscaler/test_app.py
@@ -202,7 +202,7 @@ async def test_autoscale_is_cooldown(mocker, app_factory, conn, create_action):
 async def test_autoscale_insufficient_data(mocker, app_factory, conn):
     await reset_database(conn)
     apps = [
-        app_factory('test_app', 'test_space', X_AUTOSCALING='on'),
+        app_factory('test_app', 'test_space', X_AUTOSCALING='on', X_AUTOSCALING_MIN=1),
     ]
 
     mock_get_client = mocker.patch('autoscaler.app.get_client')
@@ -308,3 +308,39 @@ async def test_autoscale_scale_down(mocker, app_factory, conn, create_metric):
 
     assert mock_notify.called
     assert mock_notify.call_args[0] == ('test_app', 'scaled down to 4 - avg cpu 5.0')
+
+
+@pytest.mark.asyncio
+async def test_autoscale_scales_up_if_below_min(mocker, app_factory, conn):
+
+    await reset_database(conn)
+
+    apps = [
+        app_factory('test_app', 'test_space', instances=1, X_AUTOSCALING='on', X_AUTOSCALING_MIN=2),
+    ]
+
+    mock_get_client = mocker.patch('autoscaler.app.get_client')
+    mock_get_client.return_value.apps.list.return_value = apps
+    with async_patch('autoscaler.app.notify') as mock_notify:
+        await autoscale(conn)
+
+    assert mock_notify.called
+    assert mock_notify.call_args[0] == ('test_app', 'scaled up as instance count is below minimum')
+
+
+@pytest.mark.asyncio
+async def test_autoscale_scales_down_if_above_max(mocker, app_factory, conn):
+
+    await reset_database(conn)
+
+    apps = [
+        app_factory('test_app', 'test_space', instances=11, X_AUTOSCALING='on', X_AUTOSCALING_MAX=10),
+    ]
+
+    mock_get_client = mocker.patch('autoscaler.app.get_client')
+    mock_get_client.return_value.apps.list.return_value = apps
+    with async_patch('autoscaler.app.notify') as mock_notify:
+        await autoscale(conn)
+
+    assert mock_notify.called
+    assert mock_notify.call_args[0] == ('test_app', 'scaled down as instance count is above maximum')


### PR DESCRIPTION
The autoscaler took no action if the current instance count was above/below min/max bounds, whilst CPU usage was in normal range.  This PR makes it scale to the min/max instance count if outside those bounds.