### PR TITLE
Bugfix scaling inflight apps

### DIFF
--- a/autoscaler/app.py
+++ b/autoscaler/app.py
@@ -288,7 +288,7 @@ async def autoscale(conn):
 
             desired_instance_count = params['instances'] - 1
             extra_text = ' [min]' if desired_instance_count == params['min_instances'] else ''
-            notification = f'scaled down to {desired_instance_count} - avg cpu {average_cpu}{extra_text}'
+            notification = f'scaled down to {desired_instance_count} - avg cpu {average_cpu:.2f}{extra_text}'
 
         elif (average_cpu > params['high_threshold'] and
             params['instances'] < params['max_instances'] and
@@ -296,7 +296,7 @@ async def autoscale(conn):
 
             desired_instance_count = params['instances'] + 1
             extra_text = ' [max]' if desired_instance_count == params['max_instances'] else ''
-            notification = f'scaled up to {desired_instance_count} - avg cpu {average_cpu}{extra_text}'
+            notification = f'scaled up to {desired_instance_count} - avg cpu {average_cpu:.2f}{extra_text}'
 
         if notification:
             await notify(app_name, notification)

--- a/autoscaler/app.py
+++ b/autoscaler/app.py
@@ -298,9 +298,12 @@ async def autoscale(conn):
         if notification:
             await notify(app_name, notification)
 
-        if desired_instance_count != params['instances'] and app['entity']['state'] == 'STARTED':
-            await scale(app, space_name, desired_instance_count, conn)
-            PROM_SCALING_ACTIONS.inc({})
+        if desired_instance_count != params['instances']:
+            summary = await loop.run_in_executor(None, app.summary)
+
+            if summary['state'] == 'STARTED':
+                await scale(app, space_name, desired_instance_count, conn)
+                PROM_SCALING_ACTIONS.inc({})
 
     PROM_INSUFFICIENT_DATA.set({}, insufficient_data_count)
     PROM_AUTOSCALING_ENABLED.set({}, len(enabled_apps))

--- a/autoscaler/app.py
+++ b/autoscaler/app.py
@@ -302,8 +302,11 @@ async def autoscale(conn):
             summary = await loop.run_in_executor(None, app.summary)
 
             if summary['state'] == 'STARTED':
-                await scale(app, space_name, desired_instance_count, conn)
-                PROM_SCALING_ACTIONS.inc({})
+                try:
+                    await scale(app, space_name, desired_instance_count, conn)
+                    PROM_SCALING_ACTIONS.inc({})
+                except:  # noqa
+                    logger.error(f'Failed to scale {space_name} / {app} to {desired_instance_count}')
 
     PROM_INSUFFICIENT_DATA.set({}, insufficient_data_count)
     PROM_AUTOSCALING_ENABLED.set({}, len(enabled_apps))

--- a/autoscaler/app.py
+++ b/autoscaler/app.py
@@ -267,9 +267,6 @@ async def autoscale(conn):
         notification = None
         desired_instance_count = params['instances']
 
-        if app['entity']['state'] != 'STARTED':
-            continue
-
         try:
             average_cpu = await get_avg_cpu(app_name, space_name, params['threshold_period'], conn)
         except InsufficientData:
@@ -301,7 +298,7 @@ async def autoscale(conn):
         if notification:
             await notify(app_name, notification)
 
-        if desired_instance_count != params['instances']:
+        if desired_instance_count != params['instances'] and app['entity']['state'] == 'STARTED':
             await scale(app, space_name, desired_instance_count, conn)
             PROM_SCALING_ACTIONS.inc({})
 

--- a/autoscaler/test_app.py
+++ b/autoscaler/test_app.py
@@ -4,7 +4,7 @@ import pytest
 from asynctest import patch as async_patch
 
 from autoscaler.app import get_autoscaling_params, is_cooldown, get_cpu_metrics, get_metrics, \
-    start_webapp, scale, InsufficientData, get_avg_cpu, get_enabled_apps, autoscale, is_new_app
+    start_webapp, scale, InsufficientData, get_avg_cpu, get_enabled_apps, autoscale
 
 from autoscaler import app as main
 
@@ -422,23 +422,3 @@ async def test_autoscale_scales_down_if_above_max(mocker, app_factory, create_me
 
     assert mock_notify.called
     assert mock_notify.call_args[0] == ('test_app', 'scaled down to 10 as instance count above maximum')
-
-
-@pytest.mark.asyncio
-async def test_is_new_app_true(conn):
-
-    await reset_database(conn)
-
-    assert await is_new_app('test_app', 'test_space', conn)
-
-
-@pytest.mark.asyncio
-async def test_is_new_app_false(create_metric, conn):
-    await reset_database(conn)
-
-    timestamp = dt.datetime.now() - dt.timedelta(15)
-
-    await create_metric(timestamp, 'test_app', 'test_space', 1, 1)
-
-    assert not await is_new_app('test_app', 'test_space', conn)
-

--- a/autoscaler/test_app.py
+++ b/autoscaler/test_app.py
@@ -298,7 +298,7 @@ async def test_autoscale_scale_up(mocker, app_factory, conn, create_metric):
         assert await cur.fetchone() == ('test_app', 'test_space', 6)
 
     assert mock_notify.called
-    assert mock_notify.call_args[0] == ('test_app', 'scaled up to 6 - avg cpu 95.0')
+    assert mock_notify.call_args[0] == ('test_app', 'scaled up to 6 - avg cpu 95.00')
 
 
 @pytest.mark.asyncio
@@ -323,7 +323,7 @@ async def test_autoscale_scale_up_indicates_it_is_at_max(mocker, app_factory, co
         await autoscale(conn)
 
     assert mock_notify.called
-    assert mock_notify.call_args[0] == ('test_app', 'scaled up to 10 - avg cpu 95.0 [max]')
+    assert mock_notify.call_args[0] == ('test_app', 'scaled up to 10 - avg cpu 95.00 [max]')
 
 
 @pytest.mark.asyncio
@@ -352,7 +352,7 @@ async def test_autoscale_scale_down(mocker, app_factory, conn, create_metric):
         assert await cur.fetchone() == ('test_app', 'test_space', 4)
 
     assert mock_notify.called
-    assert mock_notify.call_args[0] == ('test_app', 'scaled down to 4 - avg cpu 5.0')
+    assert mock_notify.call_args[0] == ('test_app', 'scaled down to 4 - avg cpu 5.00')
 
 
 @pytest.mark.asyncio
@@ -375,7 +375,7 @@ async def test_autoscale_scale_down_to_min_indicates_it_is_now_at_min(mocker, ap
         await autoscale(conn)
 
     assert mock_notify.called
-    assert mock_notify.call_args[0] == ('test_app', 'scaled down to 2 - avg cpu 5.0 [min]')
+    assert mock_notify.call_args[0] == ('test_app', 'scaled down to 2 - avg cpu 5.00 [min]')
 
 
 @pytest.mark.asyncio

--- a/conftest.py
+++ b/conftest.py
@@ -30,12 +30,13 @@ class MockCfApp:
 
 @pytest.fixture
 def app_factory():
-    def _make_app(app_name='test_app', space_name='test_space', instances=1, **env_vars):
+    def _make_app(app_name='test_app', space_name='test_space', state='STARTED', instances=1, **env_vars):
 
         app_data = {
             'entity': {
                 'name': app_name,
                 'instances': instances,
+                'state': state,
                 'environment_json': {
                 }
             },

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.5
+python-3.7.6


### PR DESCRIPTION
Autoscaler should only attempt to scale apps with status=STARTED. Also since we migrated to v3 zdt deploy the hacky `is_new_app()` function is no longer needed and has been removed.


